### PR TITLE
feat(Admin page): Add admin page

### DIFF
--- a/host/Manager.ts
+++ b/host/Manager.ts
@@ -162,7 +162,7 @@ export class Manager extends BaseExecutor {
       }
 
       // Get the session `instance` and ask it to execute the node
-      const { instance = undefined } = this.sessions[id] || {}
+      const { instance } = this.sessions[id]
       if (instance === undefined) {
         // This should never happen; if it does there is a bug in begin() or end()
         log.error(`No instance with id; already deleted, mis-routed?: ${id}`)
@@ -244,7 +244,7 @@ export class Manager extends BaseExecutor {
       const { id: sessionId } = node
       if (sessionId === undefined) return node
 
-      const { instance = undefined } = this.sessions[sessionId] || {}
+      const { instance } = this.sessions[sessionId]
       if (instance === undefined) return node
 
       const endedSession = await instance.end(node)

--- a/host/ManagerServer.ts
+++ b/host/ManagerServer.ts
@@ -1,0 +1,51 @@
+import { TcpServerClient, WebSocketAddress, WebSocketServer } from '@stencila/executa';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import fastifyStatic from 'fastify-static';
+import path from 'path';
+import { Manager } from './Manager';
+
+/**
+ * A WebSocket server for `Manager`
+ *
+ * Extends the standard `executa.WebSocketServer` with
+ * custom handlers and endpoints.
+ */
+export class ManagerServer extends WebSocketServer {
+  constructor(host = '127.0.0.1', port = 9000) {
+    super(new WebSocketAddress({ host, port }))
+
+    // Register static file serving plugin
+    this.app.register(fastifyStatic, {
+      root: path.join(__dirname, 'public'),
+      prefix: '/public/'
+    })
+
+    // Add admin page endpoint
+    this.app.get('/admin', (request: FastifyRequest, reply: FastifyReply<any>): void =>  {
+      if (request.headers['accept'].includes('application/json')) {
+        const { sessions } = this.executor as Manager
+        reply.send(sessions)
+      }
+      reply.sendFile('admin.html')
+    })
+  }
+
+  /**
+   * Handler for client disconnection.
+   *
+   * Override to end all sessions for the client.
+   */
+  async onDisconnected(client: TcpServerClient) {
+    // Call `WebSockerServer.onDisconnected` to de-register the client
+    // as normal
+    super.onDisconnected(client)
+
+    // Tell the `Manager` to end all sessions that are linked to
+    // the client
+    const manager = this.executor
+    if (manager !== undefined) {
+      // @ts-ignore that TS doesn't know that this is a Manager instance
+      await manager.endAllClient(client.id)
+    }
+  }
+}

--- a/host/ManagerServer.ts
+++ b/host/ManagerServer.ts
@@ -1,8 +1,12 @@
-import { TcpServerClient, WebSocketAddress, WebSocketServer } from '@stencila/executa';
-import { FastifyReply, FastifyRequest } from 'fastify';
-import fastifyStatic from 'fastify-static';
-import path from 'path';
-import { Manager } from './Manager';
+import {
+  TcpServerClient,
+  WebSocketAddress,
+  WebSocketServer
+} from '@stencila/executa'
+import { FastifyReply, FastifyRequest } from 'fastify'
+import fastifyStatic from 'fastify-static'
+import path from 'path'
+import { Manager } from './Manager'
 
 /**
  * A WebSocket server for `Manager`
@@ -21,13 +25,17 @@ export class ManagerServer extends WebSocketServer {
     })
 
     // Add admin page endpoint
-    this.app.get('/admin', (request: FastifyRequest, reply: FastifyReply<any>): void =>  {
-      if (request.headers['accept'].includes('application/json')) {
-        const { sessions } = this.executor as Manager
-        reply.send(sessions)
+    this.app.get(
+      '/admin',
+      (request: FastifyRequest, reply: FastifyReply<any>): void => {
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (request.headers.accept.includes('application/json')) {
+          const { sessions } = this.executor as Manager
+          reply.send(sessions)
+        }
+        reply.sendFile('admin.html')
       }
-      reply.sendFile('admin.html')
-    })
+    )
   }
 
   /**
@@ -35,7 +43,7 @@ export class ManagerServer extends WebSocketServer {
    *
    * Override to end all sessions for the client.
    */
-  async onDisconnected(client: TcpServerClient) {
+  async onDisconnected(client: TcpServerClient): Promise<void> {
     // Call `WebSockerServer.onDisconnected` to de-register the client
     // as normal
     super.onDisconnected(client)

--- a/host/public/admin.css
+++ b/host/public/admin.css
@@ -1,0 +1,7 @@
+body {
+  max-width: 50em;
+  margin: 0 auto;
+  padding: 2em;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+      Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+}

--- a/host/public/admin.html
+++ b/host/public/admin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Sparkla Admin</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="https://unpkg.com/@stencila/executa/dist/browser/index.js"></script>
+    <script
+      type="module"
+      src="https://unpkg.com/@stencila/components/dist/stencila-components/stencila-components.esm.js"
+    ></script>
+    <script
+      nomodule=""
+      src="https://unpkg.com/@stencila/components/dist/stencila-components/stencila-components.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/@stencila/components/dist/stencila-components-styles.css"
+    />
+    <link rel="stylesheet" href="/public/admin.css"/>
+  </head>
+  <body>
+    <script src="/public/admin.js"></script>
+  </body>
+</html>

--- a/host/public/admin.js
+++ b/host/public/admin.js
@@ -1,0 +1,155 @@
+const { HttpClient } = executa
+
+/**
+ * An HTTP client to connect to the `Manager`.
+ *
+ * Not using a `WebSocketClient` here because that will
+ * close any newly created sessions on disconnect which
+ * is undesirable for this app.
+ *
+ * Not using a `BaseExecutor` since we just want to send
+ * requests to the `Manager` and don't need to delegate
+ * to in-browser executors (e.g. JS or WASM).
+ */
+const executor = new HttpClient(window.location.origin)
+
+/**
+ * Create a element from HTML
+ */
+function elem(html) {
+  const div = document.createElement('div')
+  div.innerHTML = html
+  return div.firstElementChild
+}
+
+/**
+ * List all sessions with details and buttons to
+ * end and execute code in them
+ */
+async function listSessions() {
+  const response = await fetch('/admin', {
+    headers: {
+      Accept: 'application/json; charset=utf-8'
+    }
+  })
+  const sessions = await response.json()
+
+  let list = document.querySelector('#sessions')
+  if (!list) {
+    list = elem('<ul id="sessions"></ul>')
+    document.body.appendChild(list)
+  } else {
+    while (list.firstChild) list.removeChild(list.firstChild)
+  }
+  for (const id in sessions) {
+    const session = sessions[id]
+    const item = elem(
+      `<li class="session" id="${id}">
+        <details>
+          <summary>
+            ${id}
+            <button class="end">End</button>
+            <button class="select">Select</button>
+          </summary>
+          <pre><code>${JSON.stringify(session, null, '  ')}</code></pre>
+        </details>
+      </li>`
+    )
+
+    item.querySelector('button.end').onclick = () => endSession(id)
+    item.querySelector('button.select').onclick = () => selectSession(id)
+
+    list.appendChild(item)
+  }
+}
+
+/**
+ * Start by listing sessions an update every 5s
+ */
+listSessions()
+setInterval(listSessions, 5000)
+
+/**
+ * Begin a session
+ *
+ * @param session A `SoftwareSession` node with details of the
+ *                session to start
+ */
+async function beginSession(session) {
+  session = await executor.begin(session)
+  console.log('Began', session)
+  listSessions()
+}
+
+/**
+ * Add a section for creating and beginning
+ * a `SoftwareSession` node.
+ */
+const beginElem = elem(`
+    <div>
+      <textarea rows="10" cols="80">
+{
+  "type": "SoftwareSession"
+}
+      </textarea>
+      <button class="begin">Begin</button>
+    </div>
+`)
+beginElem.querySelector('button.begin').onclick = () =>
+  beginSession(JSON.parse(beginElem.querySelector('textarea').value))
+document.body.appendChild(beginElem)
+
+/**
+ * End a session
+ *
+ * @param id The id of the session to end.
+ */
+async function endSession(id) {
+  const session = await executor.end({
+      type: 'SoftwareSession',
+      id
+  })
+  console.log('Ended', session)
+  listSessions()
+}
+
+/**
+ * Section for details on a selected session
+ */
+const detailsElem = elem(`
+  <div class="details">
+    <h3 class="id">No session selected</h3>
+  </div>
+`)
+document.body.appendChild(detailsElem)
+
+/**
+ * A code chunk web component for executing
+ * code within a selected session
+ */
+const codeChunkComp = elem(`
+    <stencila-code-chunk
+      itemtype="stencila:CodeChunk"
+      data-collapsed="false"
+      data-programmingLanguage="python"
+    >
+      <pre slot="text"><code></code></pre>
+    </stencila-code-chunk>`)
+detailsElem.appendChild(codeChunkComp)
+
+/**
+ * Select a session to display in details
+ *
+ * @param id The id of the session
+ */
+function selectSession(id) {
+  detailsElem.querySelector(".id").innerText = id
+  // Attach the session to the web component
+  codeChunkComp.executeHandler = (codeChunk) => {
+    return executor.execute(codeChunk, {
+      type: 'SoftwareSession',
+      id,
+      dateStart: 'foo'
+    })
+  }
+}

--- a/host/public/admin.js
+++ b/host/public/admin.js
@@ -13,6 +13,9 @@ const { HttpClient } = executa
  * requests to the `Manager` and don't need to delegate
  * to in-browser executors (e.g. JS or WASM).
  */
+
+const jwt = new URLSearchParams(window.location.search).get('JWT_OVERRIDE')
+
 const executor = new HttpClient(window.location.origin)
 
 /**
@@ -31,7 +34,8 @@ function elem(html) {
 async function listSessions() {
   const response = await fetch('/admin', {
     headers: {
-      Accept: 'application/json; charset=utf-8'
+      Accept: 'application/json; charset=utf-8',
+      Authorization: `Bearer ${jwt}`
     }
   })
   const sessions = await response.json()

--- a/host/public/admin.js
+++ b/host/public/admin.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 const { HttpClient } = executa
 
 /**
@@ -106,8 +108,8 @@ document.body.appendChild(beginElem)
  */
 async function endSession(id) {
   const session = await executor.end({
-      type: 'SoftwareSession',
-      id
+    type: 'SoftwareSession',
+    id
   })
   console.log('Ended', session)
   listSessions()
@@ -143,9 +145,9 @@ detailsElem.appendChild(codeChunkComp)
  * @param id The id of the session
  */
 function selectSession(id) {
-  detailsElem.querySelector(".id").innerText = id
+  detailsElem.querySelector('.id').innerText = id
   // Attach the session to the web component
-  codeChunkComp.executeHandler = (codeChunk) => {
+  codeChunkComp.executeHandler = codeChunk => {
     return executor.execute(codeChunk, {
       type: 'SoftwareSession',
       id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5223,6 +5223,95 @@
         }
       }
     },
+    "fastify-static": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-2.5.0.tgz",
+      "integrity": "sha512-j0H+izfYHzlXtrMJG/3d7Z2SRhTm17HDiOZll/kWKF26GcsRTJttZneAJaF07XW/uQY9HrBRmSEwmlNG2+0b3A==",
+      "requires": {
+        "fastify-plugin": "^1.6.0",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "send": "^0.16.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+            }
+          }
+        },
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "send": {
+          "version": "0.16.2",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+          "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+        },
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
     "fastify-websocket": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/fastify-websocket/-/fastify-websocket-0.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:integ": "jest --runInBand --testPathPattern=\\.integ\\.ts$",
     "build": "tsc",
     "serve": "node dist/cli",
-    "serve:dev": "JWT_SECRET=not-a-secret ts-node-dev host/cli --debug --docker"
+    "serve:dev": "JWT_SECRET=not-a-secret ts-node-dev host/cli --debug --docker",
+    "serve:dev-jwt": "JWT_SECRET=not-a-secret ts-node host/cli --debug --docker"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@stencila/logga": "^1.4.0",
     "@stencila/schema": "^0.30.5",
     "dockerode": "^3.0.2",
-    "node-os-utils": "^1.1.0"
+    "node-os-utils": "^1.1.0",
+    "fastify-static": "^2.5.0"
   },
   "prettier": "@stencila/dev-config/prettier-config.json",
   "commitlint": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["host/**/*.ts"]
+  "include": ["host/**/*.ts", "host/**/*.js"]
 }


### PR DESCRIPTION
Begins #20. 

To view:

```bash
npm run serve -- --docker
```

and go to `/admin`.

Apart from making it a _little_ more visually appealing, we need to secure it so that it can not be . Options for that:

- only allow access if `admin` in JWT
- or, use another env var `ADMIN_PASS`
- get JWT/pswd from the URL query params

@beneboy happy to pass this over to you.

Ping @alex-ketch FYI Web Component and Executa in browser usage
