### PR TITLE
feat(Configuration): Add runtime configuration

### DIFF
--- a/.sparklarc
+++ b/.sparklarc
@@ -1,0 +1,39 @@
+{
+  // Output debug level log entries?
+  "debug": false,
+
+  // Number of seconds to provide clients with
+  // a warning prior to reaching maximum session duration.
+  "durationWarning": 600,
+
+  // Interval in seconds between checks
+  // for expired sessions.
+  "expiryInterval": 15,
+
+  // The host address that the server should listen on
+  "host": "127.0.0.1",
+
+  // The port that the server should listen on
+  "port": 9000,
+
+  // Export stats for Prometheus?
+  "prometheus": true,
+
+  // The class of sessions created.
+  "sessionType": "docker",
+
+  // Interval in seconds between checks
+  // for stale sessions.
+  "staleInterval": 60,
+
+  // Number of seconds that a stopped session is
+  // considered stale and will be removed from the list of sessions.
+  "stalePeriod": 3600,
+
+  // Collect statistics on session and system status?
+  "stats": true,
+
+  // Number of seconds to provide clients with
+  // a warning prior to a reaching session timeout.
+  "timeoutWarning": 60
+}

--- a/.sparklarc
+++ b/.sparklarc
@@ -2,25 +2,26 @@
   // Output debug level log entries?
   "debug": false,
 
-  // Number of seconds to provide clients with
-  // a warning prior to reaching maximum session duration.
-  "durationWarning": 600,
+  // The host address that the server should listen on.
+  "host": "127.0.0.1",
+
+  // The port that the server should listen on.
+  "port": 9000,
+
+  // The class of sessions created.
+  "sessionType": "docker",
 
   // Interval in seconds between checks
   // for expired sessions.
   "expiryInterval": 15,
 
-  // The host address that the server should listen on
-  "host": "127.0.0.1",
+  // Number of seconds to provide clients with
+  // a warning prior to reaching maximum session duration.
+  "durationWarning": 600,
 
-  // The port that the server should listen on
-  "port": 9000,
-
-  // Export stats for Prometheus?
-  "prometheus": true,
-
-  // The class of sessions created.
-  "sessionType": "docker",
+  // Number of seconds to provide clients with
+  // a warning prior to a reaching session timeout.
+  "timeoutWarning": 60,
 
   // Interval in seconds between checks
   // for stale sessions.
@@ -33,7 +34,6 @@
   // Collect statistics on session and system status?
   "stats": true,
 
-  // Number of seconds to provide clients with
-  // a warning prior to a reaching session timeout.
-  "timeoutWarning": 60
+  // Export stats for Prometheus?
+  "prometheus": true
 }

--- a/README.md
+++ b/README.md
@@ -48,11 +48,31 @@ Then run, Sparkla using the command line interface e.g.
 sparkla --docker
 ```
 
-Options:
+### Options
 
-- `--firecracker`: run sessions as Firecracker microVMs (default)
-- `--docker`: run sessions as Docker containers
-- `--debug`: emit debug log messages
+<!-- OPTIONS-BEGIN -->
+
+| Name    | Description       | Type        | Default |
+| ------- | ----------------- | ----------- | ------- |
+|debug               |Output debug level log entries?                                                                     |boolean             |false          |
+|durationWarning     |Number of seconds to provide clients with a warning prior to reaching maximum session duration.     |number              |600            |
+|expiryInterval      |Interval in seconds between checks for expired sessions.                                            |number              |15             |
+|host                |The host address that the server should listen on                                                   |string              |"127.0.0.1"    |
+|port                |The port that the server should listen on                                                           |number              |9000           |
+|prometheus          |Export stats for Prometheus?                                                                        |boolean             |true           |
+|sessionType         |The class of sessions created.                                                                      |"firecracker" ,  "docker"|"docker"       |
+|staleInterval       |Interval in seconds between checks for stale sessions.                                              |number              |60             |
+|stalePeriod         |Number of seconds that a stopped session is considered stale and will be removed from the list of sessions.|number              |3600           |
+|stats               |Collect statistics on session and system status?                                                    |boolean             |true           |
+|timeoutWarning      |Number of seconds to provide clients with a warning prior to a reaching session timeout.            |number              |60             |
+
+<!-- OPTIONS-END -->
+
+All options can be set, in decending order of priority, by:
+
+- a command line argument e.g. `--port 80`
+- an environment variable prefixed with `SPARKLA_` e.g. `SPARKLA_PORT=80`
+- a `.json` or `.ini` configuration file, set using the `--config` option, or `.sparklarc` by default
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -50,23 +50,25 @@ sparkla --docker
 
 ### Options
 
+<!-- prettier-ignore-start -->
 <!-- OPTIONS-BEGIN -->
 
-| Name    | Description       | Type        | Default |
-| ------- | ----------------- | ----------- | ------- |
-|debug               |Output debug level log entries?                                                                     |boolean             |false          |
-|durationWarning     |Number of seconds to provide clients with a warning prior to reaching maximum session duration.     |number              |600            |
-|expiryInterval      |Interval in seconds between checks for expired sessions.                                            |number              |15             |
-|host                |The host address that the server should listen on                                                   |string              |"127.0.0.1"    |
-|port                |The port that the server should listen on                                                           |number              |9000           |
-|prometheus          |Export stats for Prometheus?                                                                        |boolean             |true           |
-|sessionType         |The class of sessions created.                                                                      |"firecracker" ,  "docker"|"docker"       |
-|staleInterval       |Interval in seconds between checks for stale sessions.                                              |number              |60             |
-|stalePeriod         |Number of seconds that a stopped session is considered stale and will be removed from the list of sessions.|number              |3600           |
-|stats               |Collect statistics on session and system status?                                                    |boolean             |true           |
-|timeoutWarning      |Number of seconds to provide clients with a warning prior to a reaching session timeout.            |number              |60             |
+| Name            | Description                                                                                                              | Type                           | Default              |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------ | -------------------- |
+| debug           | Output debug level log entries?                                                                                          | boolean                        | false                |
+| host            | The host address that the server should listen on.                                                                       | string                         | "127.0.0.1"          |
+| port            | The port that the server should listen on.                                                                               | number                         | 9000                 |
+| sessionType     | The class of sessions created.                                                                                           | "firecracker", "docker"        | "docker"             |
+| expiryInterval  | Interval in seconds between checks for expired sessions.                                                                 | number                         | 15                   |
+| durationWarning | Number of seconds to provide clients with a warning prior to reaching maximum session duration.                          | number                         | 600                  |
+| timeoutWarning  | Number of seconds to provide clients with a warning prior to a reaching session timeout.                                 | number                         | 60                   |
+| staleInterval   | Interval in seconds between checks for stale sessions.                                                                   | number                         | 60                   |
+| stalePeriod     | Number of seconds that a stopped session is considered stale and will be removed from the list of sessions.              | number                         | 3600                 |
+| stats           | Collect statistics on session and system status?                                                                         | boolean                        | true                 |
+| prometheus      | Export stats for Prometheus?                                                                                             | boolean                        | true                 |
 
 <!-- OPTIONS-END -->
+<!-- prettier-ignore-end -->
 
 All options can be set, in decending order of priority, by:
 

--- a/docs.ts
+++ b/docs.ts
@@ -16,7 +16,9 @@ const file = app.convert(['./host/Config.ts'])
 const clas = Object.values(file.reflections).filter(
   clas => clas.kindString === 'Class'
 )[0]
-const props = clas.children.sort((a, b) => a.sources[0].line > b.sources[0].line ? 1 : -1)
+const props = clas.children.sort((a, b) =>
+  a.sources[0].line > b.sources[0].line ? 1 : -1
+)
 
 // Generate a sample JSON config file with comments
 const json = `{
@@ -37,15 +39,24 @@ fs.writeFileSync('.sparklarc', json)
 // Generate Markdown table and insert into README
 const widths = [15, 120, 30, 20]
 const name = (name, col) => name.padEnd(widths[col])
-const dashes = (col) => '-'.repeat(widths[col])
+const dashes = col => '-'.repeat(widths[col])
 const md = `
-| ${name('Name', 0)} | ${name('Description', 1)} | ${name('Type', 2)} | ${name('Default', 3)} |
+| ${name('Name', 0)} | ${name('Description', 1)} | ${name('Type', 2)} | ${name(
+  'Default',
+  3
+)} |
 | ${dashes(0)} | ${dashes(1)} | ${dashes(2)} | ${dashes(3)} |
 ${props
   .map(prop => {
     const name = prop.name.padEnd(widths[0])
-    const comment = prop.comment.shortText.trim().replace(/\s+/gm, ' ').padEnd(widths[1])
-    const type = prop.type.toString().replace(/\s*\|\s*/, ', ').padEnd(widths[2])
+    const comment = prop.comment.shortText
+      .trim()
+      .replace(/\s+/gm, ' ')
+      .padEnd(widths[1])
+    const type = prop.type
+      .toString()
+      .replace(/\s*\|\s*/, ', ')
+      .padEnd(widths[2])
     const defaultValue = prop.defaultValue.padEnd(widths[3])
     return `| ${name} | ${comment} | ${type} | ${defaultValue} |`
   })

--- a/docs.ts
+++ b/docs.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck because the typedoc typings are painful to work with :/
+
+/**
+ * Script to generate docs for configuration options
+ */
+
+import * as typedoc from '@gerrit0/typedoc'
+import fs from 'fs'
+
+const app = new typedoc.Application({
+  module: 'commonjs',
+  target: 'es2017'
+})
+
+const file = app.convert(['./host/Config.ts'])
+const clas = Object.values(file.reflections).filter(
+  clas => clas.kindString === 'Class'
+)[0]
+const props = clas.children
+
+// Generate a sample JSON config file with comments
+const json = `{
+${props
+  .map(prop => {
+    const {
+      comment: { shortText },
+      name,
+      defaultValue
+    } = prop
+    const comment = shortText.trim().replace('\n', '\n  // ')
+    return `  // ${comment}\n  "${name}": ${defaultValue}`
+  })
+  .join(',\n\n')}
+}`
+fs.writeFileSync('.sparklarc', json)
+
+// Generate Markdown table and insert into README
+const md = `
+| Name    | Description       | Type        | Default |
+| ------- | ----------------- | ----------- | ------- |
+${props
+  .map(prop => {
+    const { name, defaultValue } = prop
+    const comment = prop.comment.shortText.trim().replace(/\s+/gm, ' ')
+    const type = prop.type.toString().replace('|', ', ')
+    return `|${name.padEnd(20)}|${comment.padEnd(
+      100
+    )}|${type.padEnd(20)}|${defaultValue.padEnd(15)}|`
+  })
+  .join('\n')}
+`
+const readme = fs
+  .readFileSync('README.md', 'utf8')
+  .replace(
+    /<!-- OPTIONS-BEGIN -->[\s\S]*?<!-- OPTIONS-END -->/gm,
+    `<!-- OPTIONS-BEGIN -->\n${md}\n<!-- OPTIONS-END -->`
+  )
+fs.writeFileSync('README.md', readme)

--- a/host/Config.ts
+++ b/host/Config.ts
@@ -1,0 +1,63 @@
+import { PrometheusStatsExporter } from "@opencensus/exporter-prometheus";
+
+export class Config {
+  /**
+   * Output debug level log entries?
+   */
+  debug: boolean = false
+
+  /**
+   * The host address that the server should listen on
+   */
+  host = '127.0.0.1'
+
+  /**
+   * The port that the server should listen on
+   */
+  port: number = 9000
+
+  /**
+   * The class of sessions created.
+   */
+  sessionType: 'firecracker' | 'docker' = 'docker'
+
+  /**
+   * Interval in seconds between checks
+   * for expired sessions.
+   */
+  expiryInterval: number = 15
+
+  /**
+   * Number of seconds to provide clients with
+   * a warning prior to reaching maximum session duration.
+   */
+  durationWarning: number = 600
+
+  /**
+   * Number of seconds to provide clients with
+   * a warning prior to a reaching session timeout.
+   */
+  timeoutWarning: number = 60
+
+  /**
+   * Interval in seconds between checks
+   * for stale sessions.
+   */
+  staleInterval: number = 60
+
+  /**
+   * Number of seconds that a stopped session is
+   * considered stale and will be removed from the list of sessions.
+   */
+  stalePeriod: number = 3600
+
+  /**
+   * Collect statistics on session and system status?
+   */
+  stats: boolean = true
+
+  /**
+   * Export stats for Prometheus?
+   */
+  prometheus: boolean = true
+}

--- a/host/Config.ts
+++ b/host/Config.ts
@@ -1,20 +1,20 @@
-import { PrometheusStatsExporter } from "@opencensus/exporter-prometheus";
+import { PrometheusStatsExporter } from '@opencensus/exporter-prometheus'
 
 export class Config {
   /**
    * Output debug level log entries?
    */
-  debug: boolean = false
+  debug = false
 
   /**
-   * The host address that the server should listen on
+   * The host address that the server should listen on.
    */
   host = '127.0.0.1'
 
   /**
-   * The port that the server should listen on
+   * The port that the server should listen on.
    */
-  port: number = 9000
+  port = 9000
 
   /**
    * The class of sessions created.
@@ -25,39 +25,39 @@ export class Config {
    * Interval in seconds between checks
    * for expired sessions.
    */
-  expiryInterval: number = 15
+  expiryInterval = 15
 
   /**
    * Number of seconds to provide clients with
    * a warning prior to reaching maximum session duration.
    */
-  durationWarning: number = 600
+  durationWarning = 600
 
   /**
    * Number of seconds to provide clients with
    * a warning prior to a reaching session timeout.
    */
-  timeoutWarning: number = 60
+  timeoutWarning = 60
 
   /**
    * Interval in seconds between checks
    * for stale sessions.
    */
-  staleInterval: number = 60
+  staleInterval = 60
 
   /**
    * Number of seconds that a stopped session is
    * considered stale and will be removed from the list of sessions.
    */
-  stalePeriod: number = 3600
+  stalePeriod = 3600
 
   /**
    * Collect statistics on session and system status?
    */
-  stats: boolean = true
+  stats = true
 
   /**
    * Export stats for Prometheus?
    */
-  prometheus: boolean = true
+  prometheus = true
 }

--- a/host/Manager.integ.ts
+++ b/host/Manager.integ.ts
@@ -18,7 +18,6 @@ import {
   softwareSession
 } from '@stencila/schema'
 import JWT from 'jsonwebtoken'
-import { DockerSession } from './DockerSession'
 import { Manager } from './Manager'
 
 let manager: Manager
@@ -34,7 +33,7 @@ beforeAll(async () => {
     }
     // Start a manager locally and get it's
     // address (which contains a JWT)
-    manager = new Manager(DockerSession)
+    manager = new Manager()
     await manager.start()
     address = manager.addresses().ws as WebSocketAddress
   } else {

--- a/host/Manager.test.ts
+++ b/host/Manager.test.ts
@@ -1,11 +1,10 @@
 import { Manager } from './Manager'
-import { DockerSession } from './DockerSession'
 
 beforeAll(() => {
   process.env.JWT_SECRET = 'not-a-secret-at-all'
 })
 
 test('can be constructed', () => {
-  const manager = new Manager(DockerSession)
+  const manager = new Manager()
   expect(manager instanceof Manager).toBe(true)
 })

--- a/host/Manager.ts
+++ b/host/Manager.ts
@@ -19,7 +19,7 @@ import { FirecrackerSession } from './FirecrackerSession'
 import { ManagerServer } from './ManagerServer'
 import { Session } from './Session'
 import { optionalMin } from './util'
-import { Config } from './Config';
+import { Config } from './Config'
 
 const log = getLogger('sparkla:manager')
 const statusTagKey = { name: 'status' }
@@ -198,6 +198,7 @@ export class Manager extends BaseExecutor {
         // Client is requesting a session that has already ended
         // and been removed
         return {
+          // @ts-ignore TS2698: Spread types may only be created from object types
           ...node,
           errors: [
             codeError('error', {
@@ -216,6 +217,7 @@ export class Manager extends BaseExecutor {
       if (status === 'stopped') {
         let message = 'Session has ended.'
         if (typeof description === 'string') message += ' ' + description
+        // @ts-ignore TS2698: Spread types may only be created from object types
         return { ...node, errors: [codeError('error', { message })] }
       }
 
@@ -232,6 +234,7 @@ export class Manager extends BaseExecutor {
         )
         if (maxClients !== undefined && clients.length >= maxClients) {
           return {
+            // @ts-ignore TS2698: Spread types may only be created from object types
             ...node,
             errors: [
               codeError('error', {
@@ -276,6 +279,7 @@ export class Manager extends BaseExecutor {
         // The requested session overrides the properties of the
         // default session (or, to put it the other way around, the
         // default fills in the missing properties of the requested)
+        // @ts-ignore TS2698: Spread types may only be created from object types
         const sessionRequested = { ...this.sessionDefault, ...node }
 
         // The `user.session` overrides the properties of the
@@ -298,7 +302,10 @@ export class Manager extends BaseExecutor {
 
         // Actually start the session and return the updated
         // `SoftwareSession` node.
-        const instance = this.config.sessionType === 'docker' ? new DockerSession() : new FirecrackerSession()
+        const instance =
+          this.config.sessionType === 'docker'
+            ? new DockerSession()
+            : new FirecrackerSession()
         const dateStart = date(new Date().toISOString())
         const begunSession = await instance.begin({
           ...sessionPermitted,
@@ -334,6 +341,7 @@ export class Manager extends BaseExecutor {
    * @param notify Notify clients that the session will be ended?
    * @param reason The reason for ending the session
    */
+
   // eslint-disable-next-line @typescript-eslint/require-await
   public async end<NodeType extends Node>(
     node: NodeType,
@@ -366,6 +374,7 @@ export class Manager extends BaseExecutor {
 
       // End the session node and store it
       const endedSession = softwareSession({
+        // @ts-ignore TS2698: Spread types may only be created from object types
         ...node,
         dateEnd: date(new Date().toISOString()),
         status: 'stopped',
@@ -421,7 +430,10 @@ export class Manager extends BaseExecutor {
    * either of these.
    */
   protected endExpired(): void {
-    const { sessions, config: {durationWarning, timeoutWarning}} = this
+    const {
+      sessions,
+      config: { durationWarning, timeoutWarning }
+    } = this
     Object.entries(sessions).map(
       ([sessionId, { node, dateStart, dateLast, clients }]) => {
         const {
@@ -491,7 +503,9 @@ export class Manager extends BaseExecutor {
    * cleanup when forcing shutdown of a manager.
    */
   public endAll(): Promise<void> {
-    const { config: {sessionType}} = this
+    const {
+      config: { sessionType }
+    } = this
     if (sessionType === 'docker') return DockerSession.endAll()
     if (sessionType === 'firecracker') return FirecrackerSession.endAll()
     return Promise.resolve()
@@ -505,7 +519,10 @@ export class Manager extends BaseExecutor {
    * so that the reason for closing can be reported to user).
    */
   protected removeStale(): void {
-    const { sessions, config: {stalePeriod}} = this
+    const {
+      sessions,
+      config: { stalePeriod }
+    } = this
     Object.entries(sessions).map(([sessionId, { node: { dateEnd } }]) => {
       if (dateEnd !== undefined) {
         const now = Date.now()

--- a/host/cli.ts
+++ b/host/cli.ts
@@ -40,7 +40,7 @@ Options:
   ...and many more, see the docs or provided config file.
 `
 
-let {_: commands, ...options} = rc('sparkla', new Config())
+let { _: commands, ...options } = rc('sparkla', new Config())
 commands = commands.length === 0 ? ['serve'] : commands
 
 const config = options as Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,6 +2079,12 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
+    "@types/rc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/rc/-/rc-1.1.0.tgz",
+      "integrity": "sha512-qw1q31xPnaeExbOA1daA3nfeKW2uZQN4Xg8QqZDM3vsXPHK/lyDpjWXJQIcrByRDcBzZJ3ccchSMMTDtCWgFpA==",
+      "dev": true
+    },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -3849,8 +3855,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -6792,8 +6797,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "6.5.2",
@@ -13641,7 +13645,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -13652,14 +13655,12 @@
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,45 @@
         }
       }
     },
+    "@gerrit0/typedoc": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@gerrit0/typedoc/-/typedoc-0.15.8.tgz",
+      "integrity": "sha512-pOJny6TdrDsy1CBCsjzUuTGji4QAkOIHu5Q0TUWojMeN00hDXPG2M26r2Kt8oo3CEDZyZlP/Fy0yP8PHwJAX6Q==",
+      "dev": true,
+      "requires": {
+        "@gerrit0/typedoc-default-themes": "^0.6.1",
+        "@types/minimatch": "3.0.3",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.4.3",
+        "highlight.js": "^9.15.10",
+        "lodash": "^4.17.15",
+        "marked": "^0.7.0",
+        "minimatch": "^3.0.0",
+        "progress": "^2.0.3",
+        "shelljs": "^0.8.3",
+        "typescript": "3.6.x"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+          "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+          "dev": true
+        }
+      }
+    },
+    "@gerrit0/typedoc-default-themes": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@gerrit0/typedoc-default-themes/-/typedoc-default-themes-0.6.3.tgz",
+      "integrity": "sha512-GjEOkJ/qj5lysgf9lz2jAsGP1dXJvhmPijDKYVc1GqB+5Vy6YLbJt5PapHec2QEiMTq7gWNiHEAYR3+mnI3lAg==",
+      "dev": true,
+      "requires": {
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.6",
+        "underscore": "^1.9.1"
+      }
+    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -2775,6 +2814,15 @@
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
       }
     },
     "balanced-match": {
@@ -6444,6 +6492,12 @@
         }
       }
     },
+    "highlight.js": {
+      "version": "9.16.2",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.16.2.tgz",
+      "integrity": "sha512-feMUrVLZvjy0oC7FVJQcSQRqbBq9kwqnYE4+Kj9ZjbHh3g+BisiPgF49NyQbVLNdrL/qqZr3Ca9yOKwgn2i/tw==",
+      "dev": true
+    },
     "hook-std": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
@@ -6819,6 +6873,12 @@
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
     },
     "into-stream": {
       "version": "5.1.1",
@@ -8159,6 +8219,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8668,6 +8734,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lunr": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
+      "integrity": "sha512-oxMeX/Y35PNFuZoHp+jUj5OSEmLCaIH4KTFJh7a93cHBoFmpw2IoPs22VIz7vyO2YUnx2Tn9dzIwO2P/4quIRg==",
+      "dev": true
     },
     "macos-release": {
       "version": "2.3.0",
@@ -13714,6 +13786,15 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -14624,6 +14705,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -16044,9 +16136,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "uglify-js": {
@@ -16064,6 +16156,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,12 +15,17 @@
     "test:unit": "jest --testPathPattern=\\.test\\.ts$",
     "test:integ": "jest --runInBand --testPathPattern=\\.integ\\.ts$",
     "build": "tsc",
+    "docs": "npm run docs:options",
+    "docs:options": "ts-node docs",
+    "cli": "node dist/cli",
+    "cli:dev": "ts-node host/cli",
     "serve": "node dist/cli serve",
     "serve:dev": "JWT_SECRET=not-a-secret ts-node-dev host/cli serve --debug",
     "serve:dev-jwt": "JWT_SECRET=not-a-secret ts-node host/cli serve --debug"
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "@gerrit0/typedoc": "^0.15.8",
     "@stencila/dev-config": "1.2.2",
     "@stencila/dockta": "0.16.1",
     "@types/continuation-local-storage": "3.2.2",
@@ -32,7 +37,7 @@
     "ts-jest": "24.1.0",
     "ts-node": "8.4.1",
     "ts-node-dev": "1.0.0-pre.44",
-    "typescript": "3.6.4"
+    "typescript": "^3.7.2"
   },
   "dependencies": {
     "@opencensus/core": "0.0.18",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "test:unit": "jest --testPathPattern=\\.test\\.ts$",
     "test:integ": "jest --runInBand --testPathPattern=\\.integ\\.ts$",
     "build": "tsc",
-    "serve": "node dist/cli",
-    "serve:dev": "JWT_SECRET=not-a-secret ts-node-dev host/cli --debug --docker",
-    "serve:dev-jwt": "JWT_SECRET=not-a-secret ts-node host/cli --debug --docker"
+    "serve": "node dist/cli serve",
+    "serve:dev": "JWT_SECRET=not-a-secret ts-node-dev host/cli serve --debug",
+    "serve:dev-jwt": "JWT_SECRET=not-a-secret ts-node host/cli serve --debug"
   },
   "license": "Apache-2.0",
   "devDependencies": {
@@ -27,6 +27,7 @@
     "@types/dockerode": "2.5.20",
     "@types/jest": "24.0.22",
     "@types/node-os-utils": "1.1.0",
+    "@types/rc": "^1.1.0",
     "jest": "24.9.0",
     "ts-jest": "24.1.0",
     "ts-node": "8.4.1",
@@ -41,7 +42,8 @@
     "dockerode": "^3.0.2",
     "fastify-static": "^2.5.0",
     "moniker": "^0.1.2",
-    "node-os-utils": "^1.1.0"
+    "node-os-utils": "^1.1.0",
+    "rc": "^1.2.8"
   },
   "prettier": "@stencila/dev-config/prettier-config.json",
   "commitlint": {


### PR DESCRIPTION
This PR makes it easier to configure Sparkla. It uses `rc` to provide flexibility in how to configure and `typedoc` to provide documentation on those options.